### PR TITLE
VFE Classical integration of clay, concrete, and bronze

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -22,5 +22,7 @@
 		<li>vanillaexpanded.helixiengas</li>
 		<li>vanillaexpanded.vchemfuele</li>
 		<li>cixwow.helixiengasproduction</li>
+		<li>OskarPotocki.VFE.Classical</li>
+		<li>syrchalis.processor.framework</li>
 	</loadAfter>
 </ModMetaData>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -4,5 +4,6 @@
     <li IfModActive="dankpyon.medieval.overhaul">Mods and Shit/Medieval Overhaul</li>
     <li IfModActive="kentington.saveourship2">Mods and Shit/SOS2</li>
     <li IfModActive="vanillaexpanded.vfeproduction">Mods and Shit/VFE Production</li>
+    <li IfModActive="OskarPotocki.VFE.Classical">Mods and Shit/VFE Classical</li>
   </v1.5>
 </loadFolders>

--- a/Mods and Shit/VFE Classical/Defs/vfe classical processes.xml
+++ b/Mods and Shit/VFE Classical/Defs/vfe classical processes.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Defs>
+	<!-- concrete -->
+	<ProcessorFramework.ProcessDef Abstract="True" Name="Ferny_Make_ConcreteProcessBase" MayRequire="syrchalis.processor.framework">
+		<thingDef>VFEC_BlocksConcrete</thingDef>
+		<ingredientFilter>
+			<categories>
+				<li>StoneChunks</li>
+			</categories>
+		</ingredientFilter>
+		<capacityFactor>20</capacityFactor>
+		<efficiency>20</efficiency>
+		<usesTemperature>false</usesTemperature>
+	</ProcessorFramework.ProcessDef>
+
+	<ProcessorFramework.ProcessDef ParentName="Ferny_Make_ConcreteProcessBase" MayRequire="syrchalis.processor.framework">
+		<defName>Ferny_Make_ConcreteProcessSlow</defName>
+		<processDays>5</processDays>
+	</ProcessorFramework.ProcessDef>
+
+	<ProcessorFramework.ProcessDef ParentName="Ferny_Make_ConcreteProcessBase" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+		<defName>Ferny_Make_ConcreteProcessFast</defName>
+		<processDays>2</processDays>
+	</ProcessorFramework.ProcessDef>
+
+	<!-- clay chunk -->
+	<ProcessorFramework.ProcessDef MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+		<defName>Ferny_Make_ClayChunkProcess</defName>
+		<processDays>5</processDays>
+		<thingDef>DankPyon_ChunkClay</thingDef>
+		<ingredientFilter>
+			<thingDefs>
+				<li>DankPyon_Clay</li>
+			</thingDefs>
+		</ingredientFilter>
+		<capacityFactor>1</capacityFactor>
+		<efficiency>0.02</efficiency>
+		<usesTemperature>false</usesTemperature>
+	</ProcessorFramework.ProcessDef>
+
+	<!-- bronze -->
+	<ProcessorFramework.ProcessDef Abstract="True" Name="Ferny_Make_BronzeProcessBase" MayRequire="syrchalis.processor.framework">
+		<thingDef>VFEC_Bronze</thingDef>
+		<usesTemperature>false</usesTemperature>
+		<ingredientFilter>
+			<categories>
+				<li>StoneChunks</li>
+			</categories>
+		</ingredientFilter>
+		<capacityFactor>20</capacityFactor>
+		<efficiency>10</efficiency>
+	</ProcessorFramework.ProcessDef>
+
+	<ProcessorFramework.ProcessDef ParentName="Ferny_Make_BronzeProcessBase" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+		<defName>Ferny_Make_BronzeFromChunkProcessKiln</defName>
+		<processDays>1</processDays>
+		<filledGraphicSuffix>_Filled</filledGraphicSuffix>
+	</ProcessorFramework.ProcessDef>
+
+	<ProcessorFramework.ProcessDef ParentName="Ferny_Make_BronzeProcessBase" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+		<defName>Ferny_Make_BronzeFromChunkProcessSmelter</defName>
+		<processDays>0.5</processDays>
+		<filledGraphicSuffix>Filled</filledGraphicSuffix>
+	</ProcessorFramework.ProcessDef>
+
+	<ProcessorFramework.ProcessDef ParentName="Ferny_Make_BronzeProcessBase" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+		<defName>Ferny_Make_BronzeFromChunkProcessIndustrial</defName>
+		<processDays>0.25</processDays>
+	</ProcessorFramework.ProcessDef>
+
+</Defs>

--- a/Mods and Shit/VFE Classical/Patches/vfe classical patch.xml
+++ b/Mods and Shit/VFE Classical/Patches/vfe classical patch.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+	<!-- more concrete interactions -->
+
+	<Operation Class="PatchOperationSequence">
+		<operations>
+			<!-- cement press -->
+			<li Class="PatchOperationAdd" MayRequire="syrchalis.processor.framework">
+				<xpath>/Defs/ThingDef[defName="VFEC_ConcretePress"]</xpath>
+				<value>
+					<hasInteractionCell>True</hasInteractionCell>
+					<interactionCellOffset>(0,0,2)</interactionCellOffset>
+					<placeWorkers>
+						<li>PlaceWorker_PreventInteractionSpotOverlap</li>
+					</placeWorkers>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace" MayRequire="syrchalis.processor.framework">
+				<xpath>/Defs/ThingDef[defName="VFEC_ConcretePress"]/tickerType</xpath>
+				<value>
+					<tickerType>Rare</tickerType>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace" MayRequire="syrchalis.processor.framework">
+				<xpath>/Defs/ThingDef[defName="VFEC_ConcretePress"]/thingClass</xpath>
+				<value>
+					<thingClass>Building_WorkTable</thingClass>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd" MayRequire="syrchalis.processor.framework">
+				<xpath>/Defs/ThingDef[defName="VFEC_ConcretePress"]</xpath>
+				<value>
+					<drawerType>MapMeshAndRealTime</drawerType>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace" MayRequire="syrchalis.processor.framework">
+				<xpath>/Defs/ThingDef[defName="VFEC_ConcretePress"]/comps/li[@Class="ItemProcessor.CompProperties_ItemProcessor"]</xpath>
+				<value>
+					<li Class="ProcessorFramework.CompProperties_Processor">
+						<capacity>200</capacity>
+						<processes>
+							<li>Ferny_Make_ConcreteProcessSlow</li>
+							<li MayRequire="dankpyon.medieval.overhaul">Ferny_Make_ClayChunkProcess</li>
+						</processes>
+					</li>
+					<li Class="CompProperties_Forbiddable" />
+				</value>
+			</li>
+
+			<!-- windmill -->
+			<li Class="PatchOperationAdd" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+				<xpath>/Defs/ThingDef[defName="DankPyon_WindMill"]/comps/li[@Class="ProcessorFramework.CompProperties_Processor"]/processes</xpath>
+				<value>
+					<li>Ferny_Make_ConcreteProcessFast</li>
+				</value>
+			</li>
+
+			<!-- watermill -->
+			<li Class="PatchOperationAdd" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+				<xpath>/Defs/ThingDef[defName="DankPyon_WaterMill"]/comps/li[@Class="ProcessorFramework.CompProperties_Processor"]/processes</xpath>
+				<value>
+					<li>Ferny_Make_ConcreteProcessFast</li>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+	<!-- more bronze interactions -->
+	<Operation Class="PatchOperationSequence">
+		<operations>
+			<!-- bronze item update -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/description</xpath>
+				<value>
+					<description>A metallic alloy made from trace elements found in stone. Can be used for crafting armor or furnishings when steel is in low supply.</description>
+				</value>
+			</li>
+
+			<!-- recipe update -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/RecipeDef[defName="VFEC_Make_Bronze"]/description</xpath>
+				<value>
+					<description>Make bronze from stone chunks.</description>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/RecipeDef[defName="VFEC_Make_Bronze"]/recipeUsers</xpath>
+				<value>
+					<recipeUsers>
+						<li>ElectricSmelter</li>
+						<li MayRequire="dankpyon.medieval.overhaul">DankPyon_Furnace</li>
+					</recipeUsers>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/RecipeDef[defName="VFEC_Make_Bronze"]/ingredients</xpath>
+				<value>
+					<ingredients>
+						<li>
+							<filter>
+								<categories>
+									<li>StoneChunks</li>
+								</categories>
+							</filter>
+							<count>1</count>
+						</li>
+					</ingredients>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/RecipeDef[defName="VFEC_Make_Bronze"]/fixedIngredientFilter</xpath>
+				<value>
+					<fixedIngredientFilter>
+						<categories>
+							<li>StoneChunks</li>
+						</categories>
+					</fixedIngredientFilter>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/RecipeDef[defName="VFEC_Make_Bronze"]/products</xpath>
+				<value>
+					<products>
+						<VFEC_Bronze>10</VFEC_Bronze>
+					</products>
+				</value>
+			</li>
+
+			<!-- kiln -->
+			<li Class="PatchOperationReplace" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+				<xpath>/Defs/ThingDef[defName="DankPyon_Kiln"]/description</xpath>
+				<value>
+					<description>A stone kiln used to cook raw clay into bricks or chunks into bronze.</description>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+				<xpath>/Defs/ThingDef[defName="DankPyon_Kiln"]/comps/li[@Class="ProcessorFramework.CompProperties_Processor"]/processes</xpath>
+				<value>
+					<li>Ferny_Make_BronzeFromChunkProcessKiln</li>
+				</value>
+			</li>
+
+			<!-- smelter -->
+			<li Class="PatchOperationAdd" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+				<xpath>/Defs/ThingDef[defName="DankPyon_Smelter"]/comps/li[@Class="ProcessorFramework.CompProperties_Processor"]/processes</xpath>
+				<value>
+					<li>Ferny_Make_BronzeFromChunkProcessSmelter</li>
+				</value>
+			</li>
+
+			<!-- blast furnace -->
+			<li Class="PatchOperationAdd" MayRequire="syrchalis.processor.framework,dankpyon.medieval.overhaul">
+				<xpath>/Defs/ThingDef[defName="DankPyon_BlastFurnace"]/comps/li[@Class="ProcessorFramework.CompProperties_Processor"]/processes</xpath>
+				<value>
+					<li>Ferny_Make_BronzeFromChunkProcessIndustrial</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Clay:
* Added process recipe for clay chunks from dig spot clay to make a renewable chunk source for flat maps.
* Updated VFEC concrete press to produce clay chunks.
* Recipe takes 5 days per operation, can run 4 jobs in parallel.
* 50 clay = 1 clay chunk.

Concrete:
* Added process recipes for concrete blocks from stone chunks.
* Updated VFEC concrete press to use slow process recipe for concrete.
* Updated MO windmill and watermill to use fast process recipe for concrete.
* Slow recipe takes 5 days per operation, can run 10 jobs in parallel.
* Fast recipe takes 2 days per operation, can run 10 jobs in parallel.
* 1 chunk = 20 concrete.

Bronze:
* Added process recipes for bronze ingots from stone chunks.
* Updated MO Kiln, MO Furnace, MO Smelter, and MO Blast Furnace to produce bronze.
* Moved recipe from Smithy to Electric Smelter to produce bronze manually.
* Progression for automated buildings MO Kiln -> MO Smelter -> MO Blast Furnace increases the speed at which bronze is processed not the yield.
* 1 chunk = 10 bronze.