### PR TITLE
Add missing recipes to MO's anvil

### DIFF
--- a/Mods and Shit/Medieval Overhaul/Patches/medieval overhual patch.xml
+++ b/Mods and Shit/Medieval Overhaul/Patches/medieval overhual patch.xml
@@ -414,6 +414,14 @@
             </match>
           </Operation>
 
+    <!-- Add recipes to Anvil that don't yet have it -->
+    <Operation Class="PatchOperationAdd">
+    <xpath>//*/recipeMaker/recipeUsers[li[.='FueledSmithy'] and not(li[.='DankPyon_Anvil'])]</xpath>
+    <value>
+      <li>DankPyon_Anvil</li>
+    </value>
+    </Operation>
+
 
 </Patch>
 


### PR DESCRIPTION
Several mods aren't patched to use MO's anvil (e.g. EPOE's steel arm, Bogleg's knuckle dusters). This now forces all recipes that can be made on the fueled smithy to also be available on the anvil.